### PR TITLE
Map webui to port 80 instead of 8000

### DIFF
--- a/dockercoins/docker-compose.yml
+++ b/dockercoins/docker-compose.yml
@@ -13,7 +13,7 @@ webui:
     links:
       - redis
     ports:
-      - "8000:80"
+      - "80:80"
     volumes:
       - "./webui/files/:/files/"
 

--- a/dockercoins/docker-compose.yml-ambassador
+++ b/dockercoins/docker-compose.yml-ambassador
@@ -27,7 +27,7 @@ webui:
     links:
       - redis
     ports:
-      - "8000:80"
+      - "80:80"
     #volumes:
     #  - "./webui/files/:/files/"
 

--- a/dockercoins/docker-compose.yml-extra-hosts
+++ b/dockercoins/docker-compose.yml-extra-hosts
@@ -27,7 +27,7 @@ webui:
     extra_hosts:
       redis: A.B.C.D
     ports:
-      - "8000:80"
+      - "80:80"
     #volumes:
     #  - "./webui/files/:/files/"
 

--- a/dockercoins/docker-compose.yml-logging
+++ b/dockercoins/docker-compose.yml-logging
@@ -19,7 +19,7 @@ webui:
     links:
       - redis
     ports:
-      - "8000:80"
+      - "80:80"
     volumes:
       - "./webui/files/:/files/"
     log_driver: gelf

--- a/dockercoins/docker-compose.yml-scaled-rng
+++ b/dockercoins/docker-compose.yml-scaled-rng
@@ -27,7 +27,7 @@ webui:
     links:
       - redis
     ports:
-      - "8000:80"
+      - "80:80"
     volumes:
       - "./webui/files/:/files/"
 

--- a/elk/docker-compose.yml
+++ b/elk/docker-compose.yml
@@ -48,7 +48,7 @@ logstash:
 kibana:
   image: kibana
   ports:
-    - 5601
+    - 8080:5601
   links:
     - elasticsearch
   environment:


### PR DESCRIPTION
Using port `8000` or some other random port didn't work in lab due to firewall rule that forbids _unknown_ ports on guest network, here's a dead simple PR to fix that. This kind of setup may be seen elsewhere.

* webui : `80`
* kibana : `8080`