### PR TITLE
add vagrant-vbguest install link

### DIFF
--- a/prepare-local/README.md
+++ b/prepare-local/README.md
@@ -13,6 +13,7 @@ Virtualbox, Vagrant and Ansible
 - Virtualbox: https://www.virtualbox.org/wiki/Downloads
 
 - Vagrant: https://www.vagrantup.com/downloads.html
+  - install vagrant-vbguest plugin (https://github.com/dotless-de/vagrant-vbguest)
 
 - Ansible:
   - install Ansible's prerequisites:


### PR DESCRIPTION
During the prepare-local setup I found that the Vagrantfile is using vagrant-vbguest plugin, so I added its install link to the readme.