### PR TITLE
"Using Docker Machine to communicate with a node" missing the `docker-machine env` command

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1213,11 +1213,11 @@ You should see your 5 nodes.
 
 ## Using Docker Machine to communicate with a node
 
-- To select a node, use `eval $(docker-machine nodeX)`
+- To select a node, use `eval $(docker-machine env nodeX)`
 
 - This sets a number of environment variables
 
-- To unset these variables, use `eval $(docker-machine -u)`
+- To unset these variables, use `eval $(docker-machine env -u)`
 
 .exercise[
 

--- a/prepare-machine/README.md
+++ b/prepare-machine/README.md
@@ -1,5 +1,4 @@
-# Setting up your own cluster
-
+# Setting up your own cluster 
 If you want to go through this orchestration workshop on your own,
 you will need a cluster of Docker nodes.
 
@@ -180,10 +179,10 @@ done
 (The command takes a while. Be patient.)
 
 
-### Local VirtualBox
+### Local VirtualBox or VMware Fusion
 
 If you want to run with local VMs, set the environment variable
-`MACHINE_DRIVER` to `virtualbox` and create your nodes:
+`MACHINE_DRIVER` to `virtualbox` or `vmwarefusion` and create your nodes:
 
 ```bash
 export MACHINE_DRIVER=virtualbox


### PR DESCRIPTION
In the section titled "Using Docker Machine to communicate with a node", the list contains a couple typos:

> * To select a node, use eval $(docker-machine nodeX)
> * This sets a number of environment variables
> * To unset these variables, use eval $(docker-machine -u)

Those `docker-machine ...` commands need to be `docker-machine env ...` commands, I believe.

Submitting PR to fix.