### PR TITLE
slides: code block comment formatting on snap install

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3951,7 +3951,7 @@ curl -sSL $RELEASEURL/snap-plugins-$SNAPVER-linux-amd64.tar.gz |
      tar -C /opt -zxf-
 ln -s snap-$SNAPVER /opt/snap
 for BIN in snapd snapctl; do ln -s /opt/snap/bin/$BIN /usr/local/bin/$BIN; done
-' If you copy-paste that block, do not forget that final quote ☺
+' # If you copy-paste that block, do not forget that final quote ☺
 ```
 
 ]


### PR DESCRIPTION
This will make it easier to copy-paste the whole block used for
snap installation