### PR TITLE
Fix link to Raft

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1092,8 +1092,8 @@ class: title
 
 ## SwarmKit features
 
-- Highly-available, distributed store based on [Raft](
-  https://en.wikipedia.org/wiki/Raft_(computer_science))
+- Highly-available, distributed store based on
+  <a href="https://en.wikipedia.org/wiki/Raft_(computer_science)">Raft</a>
   <br/>(more on next slide)
 
 - *Services* managed with a *declarative API*


### PR DESCRIPTION
The link to the Wikipedia entry for Raft has parentheses.
The version of Markdown used to render the page encounters the right parenthesis and does not include it in the actual link.

We should escape it with a backslash so that it renders correctly.

The corrected page can be viewed on my fork: https://kchien.github.io/orchestration-workshop/#48
