### PR TITLE
Corrections to the docs/index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2266,7 +2266,9 @@ There are many ways to deal with inbound traffic on a Swarm cluster.
 - Build and run the Swarm visualizer:
   ```bash
   cd docker-swarm-visualizer
-  docker-compose up -d
+  docker service create --name=viz --publish=8080:8080/tcp --constraint=node.role==manager \
+  --mount=type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+  dockersamples/visualizer  
   ```
 
 ]

--- a/docs/index.html
+++ b/docs/index.html
@@ -2555,6 +2555,8 @@ The curl command should now output:
 
 - And run this little for loop:
   ```bash
+    cd orchestration-workshop/dockercoins
+
     DOCKER_REGISTRY=127.0.0.1:5000
     TAG=v0.1
     for SERVICE in hasher rng webui worker; do

--- a/docs/index.html
+++ b/docs/index.html
@@ -4065,7 +4065,7 @@ class: extra-details
 
 - Just scale back to 10 replicas:
   ```bash
-  docker service update worker --replicas 10
+  docker service update dockercoins_worker --replicas 10
   ```
 
 - Check that they're running:

--- a/docs/index.html
+++ b/docs/index.html
@@ -4070,7 +4070,7 @@ class: extra-details
 
 - Check that they're running:
   ```bash
-  docker service ps worker
+  docker service ps dockercoins_worker
   ```
 
 ]


### PR DESCRIPTION
* Change the way Swarm Visualizer is started
Viz was beeing started with docker compose, but there is no docker compose file
in the repo git://github.com/jpetazzo/docker-swarm-visualizer. Changed from
docker-compose to service

* Add path so image build have success
Path to the compose-files of the hasher rng webui worker services
has been added so that the build has success

* Change the worker service name
Worker service name should be dockercoins_worker