### PR TITLE
Update docker node command with a working filter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4787,7 +4787,7 @@ class: node-info
 
 - `docker node ps <node_name_or_id>` shows info for another node
 
-- `docker node ps -a` includes stopped and failed tasks
+- `docker node ps -f "name=<service_name>" <node_name>` The name filter matches on all or part of a task’s name
 
 ---
 


### PR DESCRIPTION
There's a ```docker node ps -a``` command on your slides that doesn't work anymore due to updates to that command.